### PR TITLE
Standardize code replacement strings - iOS quickstart

### DIFF
--- a/MSALiOS/ViewController.swift
+++ b/MSALiOS/ViewController.swift
@@ -32,8 +32,8 @@ import MSAL
 
 class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate {
     
-    // Update the below to your client ID you received in the portal. The below is for running the demo only
-    let kClientID = "66855f8a-60cd-445e-a9bb-8cd8eadbd3fa"
+    // Update the below to your client ID you received in the portal. The below client ID is for running the demo only
+    let kClientID = "Enter_the_Application_Id_here" //"66855f8a-60cd-445e-a9bb-8cd8eadbd3fa"
     
     // Additional variables for Auth and Graph API
     let kGraphURI = "https://graph.microsoft.com/v1.0/me/"


### PR DESCRIPTION
We have a working prototype to improve developer experience in quickstarts so that the downloaded code sample is ready-to-run and no longer needs manual step of copy-pasting the code blob with clientId/password/etc info. For that, we're standardizing code replacement strings as follows:
ClientIdStringToReplace : "Enter_the_Application_Id_here"
ClientTenantToReplace : "common"